### PR TITLE
Run programs to update desktop integration

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -113,7 +113,7 @@ struct arg_struct {
 
 void update_desktop()
 {
-    const gchar *error_msgfmt = "Warning: failed to spawn %s:\n";
+    const gchar *error_msgfmt = "Warning: %s retuned non-zero exit code:\n";
     if(is_update_desktop_available && system(cmd_update_desktop) != 0) {
         THREADSAFE_G_PRINT(error_msgfmt, program_update_desktop);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -206,10 +206,10 @@ gboolean check_for_program(const gchar *program_name)
 // check if update programs are available
 void check_update_programs()
 {
-    is_update_desktop_available = check_for_program("update-desktop-database");
-    is_update_mime_available = check_for_program("update-mime-database");
-    is_gtk_update_icon_cache_available = check_for_program("gtk-update-icon-cache");
-    is_kbuildsycoca5_available = check_for_program("kbuildsycoca5");
+    is_update_desktop_available = check_for_program(program_update_desktop);
+    is_update_mime_available = check_for_program(program_update_mime);
+    is_gtk_update_icon_cache_available = check_for_program(program_gtk_update_icon_cache);
+    is_kbuildsycoca5_available = check_for_program(program_kbuildsycoca5);
 }
 
 /* Recursively process the files in this directory and its subdirectories,

--- a/src/main.c
+++ b/src/main.c
@@ -75,12 +75,15 @@ static gint64 time_last_update = 0; // in microseconds
 static const gchar *program_update_desktop = "update-desktop-database";
 static const gchar *program_update_mime = "update-mime-database";
 static const gchar *program_gtk_update_icon_cache = "gtk-update-icon-cache";
+static const gchar *program_kbuildsycoca5 = "kbuildsycoca5";
 static const gchar *cmd_update_desktop = "update-desktop-database ~/.local/share/applications/";
 static const gchar *cmd_update_mime = "update-mime-database ~/.local/share/mime/";
 static const gchar *cmd_gtk_update_icon_cache = "gtk-update-icon-cache ~/.local/share/icons/hicolor/ -t";
+static const gchar *cmd_kbuildsycoca5 = "kbuildsycoca5";
 static gboolean is_update_desktop_available = FALSE;
 static gboolean is_update_mime_available = FALSE;
 static gboolean is_gtk_update_icon_cache_available = FALSE;
+static gboolean is_kbuildsycoca5_available = FALSE;
 gchar **remaining_args = NULL;
 
 static GOptionEntry entries[] =
@@ -122,6 +125,9 @@ void update_desktop()
     }
     if(is_gtk_update_icon_cache_available && system(cmd_gtk_update_icon_cache) != 0) {
         THREADSAFE_G_PRINT(error_msgfmt, program_gtk_update_icon_cache);
+    }
+    if(is_kbuildsycoca5_available && system(cmd_kbuildsycoca5) != 0) {
+        THREADSAFE_G_PRINT(error_msgfmt, program_kbuildsycoca5);
     }
 }
 
@@ -203,6 +209,7 @@ void check_update_programs()
     is_update_desktop_available = check_for_program("update-desktop-database");
     is_update_mime_available = check_for_program("update-mime-database");
     is_gtk_update_icon_cache_available = check_for_program("gtk-update-icon-cache");
+    is_kbuildsycoca5_available = check_for_program("kbuildsycoca5");
 }
 
 /* Recursively process the files in this directory and its subdirectories,


### PR DESCRIPTION
This PR fixes issue #34.

# Implementation

It checks if the following programs are available in the users `$PATH`:
* update-desktop-database
* update-mime-database
* gtk-update-icon-cache
* kbuildsycoca5

Based on the availability of each program, it executes each of them within a thread if more than 3 seconds have passed since the last AppImage was added. If another AppImage is dropped into one of the watched directories while still within the 3 seconds, then the timer is reset. So if suddenly a user drops 20 AppImages into the directory, the update will only be executed once.

Note: The execution time of the desktop update depends on the system, but it generally falls in the 100-600ms range, according to my tests on my main machine and an older laptop.

# Tests

I have manually tested this with the Libreoffice and Subsurface AppImages on the following distributions:

* Kubuntu 18.10 (KDE)
* Ubuntu 18.10 (Gnome)
* Xubuntu 18.10 (XFCE)
* Linux Mint 19 (Cinnamon)
* Linux Mint 19 (MATE)
* Elementary 5 (Elementary)