### PR TITLE
Workaround to bundle new libappimage dependencies

### DIFF
--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -64,6 +64,17 @@ cpack -V -G RPM
 mkdir -p appdir
 make install DESTDIR=appdir
 
+# Add "hidden" dependencies; https://github.com/AppImage/libappimage/issues/104
+We want a newer patchelf since the one above is missing e.g., '--add-needed' which our users might want to use
+git clone -o e1e39f3 https://github.com/NixOS/patchelf
+cd patchelf
+bash ./bootstrap.sh
+./configure --prefix=/usr
+make -j$(nproc)
+sudo make install
+cd -
+patchelf --add-needed librsvg-2.so.2 --add-needed libcairo.so.2 --add-needed libgobject-2.0.so ./appdir/usr/bin/appimaged
+
 wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-"$ARCH".AppImage
 chmod +x linuxdeploy-"$ARCH".AppImage
 ./linuxdeploy-"$ARCH".AppImage --appimage-extract

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -65,7 +65,7 @@ mkdir -p appdir
 make install DESTDIR=appdir
 
 # Add "hidden" dependencies; https://github.com/AppImage/libappimage/issues/104
-We want a newer patchelf since the one above is missing e.g., '--add-needed' which our users might want to use
+# We need a newer patchelf with '--add-needed'
 git clone -o e1e39f3 https://github.com/NixOS/patchelf
 cd patchelf
 bash ./bootstrap.sh

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -75,6 +75,18 @@ sudo make install
 cd -
 patchelf --add-needed librsvg-2.so.2 --add-needed libcairo.so.2 --add-needed libgobject-2.0.so ./appdir/usr/bin/appimaged
 
+# Workaround for:
+# undefined symbol: g_type_check_instance_is_fundamentally_a
+# Function g_type_check_instance_is_fundamentally_a was introduced in glib2-2.41.1
+# Bundle libglib-2.0.so.0 - TODO: find a better solution, e.g., downgrade libglib-2.0 at compile time
+mkdir -p ./appdir/usr/lib/
+cp $(ldconfig -p | grep libglib-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./appdir/usr/lib/
+# The following come with glib2 and probably need to be treated together:
+cp $(ldconfig -p | grep libgio-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./appdir/usr/lib/
+cp $(ldconfig -p | grep libgmodule-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./appdir/usr/lib/
+cp $(ldconfig -p | grep libgobject-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./appdir/usr/lib/
+cp $(ldconfig -p | grep libgthread-2.0.so.0 | head -n 1 | cut -d ">" -f 2 | xargs) ./appdir/usr/lib/
+
 wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-"$ARCH".AppImage
 chmod +x linuxdeploy-"$ARCH".AppImage
 ./linuxdeploy-"$ARCH".AppImage --appimage-extract


### PR DESCRIPTION
Workaround to bundle new libappimage dependencies until https://github.com/AppImage/libappimage/issues/104 is properly solved.